### PR TITLE
Adding an 'opsCount' to the User

### DIFF
--- a/data/schema.go
+++ b/data/schema.go
@@ -85,6 +85,12 @@ func init() {
 				Type: graphql.Int,
 			},
 			"id": relay.GlobalIDField("user", nil),
+			"opsCount": &graphql.Field{
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return 42, nil
+				},
+				Type: graphql.Int,
+			},
 			"todos": &graphql.Field{
 				Args:        userToTodosCollectionArgs,
 				Description: "The todos for this user",

--- a/js/components/TodoApp.js
+++ b/js/components/TodoApp.js
@@ -63,6 +63,7 @@ export default createFragmentContainer(TodoApp, {
   viewer: graphql`
     fragment TodoApp_viewer on User {
       id,
+      opsCount,
       totalCount,
       ...TodoListFooter_viewer,
       ...TodoList_viewer,


### PR DESCRIPTION
The need is to add another property to the User object, served by GraphQL.  There are two code changes necessary, plus a little legwork.

First, obviously, we want to add the `opsCount` property to the schema, as represented in the Go code:
``` Golang
"opsCount": &graphql.Field{
    Resolve: func(p graphql.ResolveParams) (interface{}, error) {
      return 42, nil
    },
  Type: graphql.Int,
},
```

For sake of simplicity, and because it is the answer, we will always return the value 42.  Your implementation and results should vary.

At this point, we want to do our first piece of legwork.  We need to regenerate the schema file for the client.  At the command line, we will use the following:
```
yarn run update-schema
```

This will update your local copy of `schema.json`.

Next, we will return to our code, but on the client side.  There are a number of places in the JS code that request (a fragment of) the User object.  Because we just generally want the user, I changed the TodoApp component, but depending on what you might be using a new property for, there could be a better place.  

We are creating the fragment in `createFragmentContainer`, and I just inserted the `opsCount` to the list:

```
fragment TodoApp_viewer on User {
  id,
  opsCount,
  totalCount,
  ...TodoListFooter_viewer,
  ...TodoList_viewer,
}
```

That should be it, except that we are using Relay Modern, which has some compilation steps.  Return to your command line, and run:
```
yarn run build
```

In this project, that will invoke `relay-compiler`, taking in the updated `schema.json` that we rebuild above, and inspecting our JS files.  Once this is done, the application can be restarted, and we can use the Chrome developer tools to watch the network traffic to see `opsCount` request and response.